### PR TITLE
UI improvements for widescreen and mobile

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,7 +5,7 @@
             <input [(ngModel)]="term" matInput placeholder="Filter by name" type="text" />
         </mat-form-field>
         <div style="display: flex; flex-direction: row;">
-            <mat-form-field style="flex-grow: 1; margin-right: 6px;">
+            <mat-form-field style="width: calc(50% - 6px); margin-right: 6px;">
                 <mat-label>Theme</mat-label>
                 <mat-select [(ngModel)]="iconStyle">
                     <mat-option value="">Regular</mat-option>
@@ -15,7 +15,7 @@
                     <mat-option value="library-round">Rounded</mat-option>
                 </mat-select>
             </mat-form-field>
-            <mat-form-field style="flex-grow: 1; margin-left: 6px;">
+            <mat-form-field style="width: calc(50% - 6px); margin-left: 6px;">
                 <mat-label>Category</mat-label>
                 <mat-select [(ngModel)]="category">
                     <mat-option value="">All</mat-option>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -41,7 +41,7 @@
             </mat-form-field>
         </div>
     </div>
-    <div style="display: flex; flex-direction: row;">
+    <div style="display: flex; flex-direction: row;" [ngStyle]="!isSmallScreen && { 'padding-left': '36px', 'padding-right': '36px' }">
         <section *ngIf="!isSmallScreen" style="display: flex; flex-direction: column; margin-top: 16px; margin: 12px;">
             <mat-form-field floatLabel="auto" style="margin-left: 8px; margin-right: 8px;">
                 <button mat-icon-button matPrefix>
@@ -99,21 +99,24 @@
             </mat-form-field>
         </section>
         <section [class.is-small]="isSmallScreen" [ngClass]="iconStyle" class="library-container">
-            <div *ngFor="let category of groupedByCategory | filterCategory: category" class="category-group">
+            <div *ngFor="let category of groupedByCategory | filterCategory: category">
+                <h2 class="category_name">{{ category[0].categories[0] | titlecase }}</h2>
                 <!--        <div>-->
                 <!--          <span>{{category.length}} icons</span>-->
                 <!--        </div>-->
-                <app-icon-item
-                    *ngFor="
-                        let icon of category
-                            | filter: term:['sizes_px', 'version', 'categories', 'unsupported_families'];
-                        let index = index
-                    "
-                    [i]="index"
-                    [icon]="icon"
-                    [name]="icon.name"
-                >
-                </app-icon-item>
+                <div class="category-group" [ngStyle]="{ 'justify-content': isSmallScreen ? 'space-around' : 'space-between' }">
+                    <app-icon-item
+                        *ngFor="
+                            let icon of category
+                                | filter: term:['sizes_px', 'version', 'categories', 'unsupported_families'];
+                            let index = index
+                        "
+                        [i]="index"
+                        [icon]="icon"
+                        [name]="icon.name"
+                    >
+                    </app-icon-item>
+                </div>
             </div>
         </section>
     </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -43,7 +43,7 @@
     </div>
     <div style="display: flex; flex-direction: row;" [ngStyle]="!isSmallScreen && { 'padding-left': '36px', 'padding-right': '36px' }">
         <section *ngIf="!isSmallScreen" style="display: flex; flex-direction: column; margin-top: 16px; margin: 12px;">
-            <mat-form-field floatLabel="auto" style="margin-left: 8px; margin-right: 8px;">
+            <mat-form-field floatLabel="never" style="margin-left: 8px; margin-right: 8px;">
                 <button mat-icon-button matPrefix>
                     <mat-icon>search</mat-icon>
                 </button>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,12 +1,13 @@
 .library-container {
+    margin-top: 24px;
     margin-left: 36px;
     flex-grow: 1;
 
     &.is-small {
+        margin-top: -4px;
         margin-left: auto;
         padding-left: 16px;
         padding-right: 16px;
-        margin-top: -20px;
     }
 }
 
@@ -15,10 +16,6 @@
 
     &:only-child {
         visibility: hidden;
-    }
-
-    &:first-of-type {
-        margin-top: 16px;
     }
 }
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,8 +1,6 @@
 .library-container {
-    max-width: 1440px;
-    margin-right: auto;
-    padding-left: 36px;
-    padding-right: 36px;
+    margin-left: 36px;
+    flex-grow: 1;
 
     &.is-small {
         margin-left: auto;
@@ -13,8 +11,14 @@
 }
 
 .category_name {
+    width: 100%;
+
     &:only-child {
         visibility: hidden;
+    }
+
+    &:first-of-type {
+        margin-top: 16px;
     }
 }
 
@@ -33,6 +37,12 @@
     }
 }
 
-.category-group:first-of-type {
-    margin-top: 16px;
+.category-group {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 136px);
+
+    &::after {
+        content: "";
+        flex: auto;
+    }
 }

--- a/src/app/icon-item/icon-item.component.html
+++ b/src/app/icon-item/icon-item.component.html
@@ -1,4 +1,3 @@
-<h2 *ngIf="i === 0" class="category_name">{{ icon.categories[0] | titlecase }}</h2>
 <div class="icon-item-container">
     <div class="icon-item-inner-container">
         <mat-icon class="icon-item-preview" (click)="copyToClipboard(icon.name)">{{ icon.name }}</mat-icon>

--- a/src/app/icon-item/icon-item.component.html
+++ b/src/app/icon-item/icon-item.component.html
@@ -1,6 +1,6 @@
-<div class="icon-item-container">
+<div class="icon-item-container" (click)="copyToClipboard(icon.name)">
     <div class="icon-item-inner-container">
-        <mat-icon class="icon-item-preview" (click)="copyToClipboard(icon.name)">{{ icon.name }}</mat-icon>
-        <span class="icon-item-title" (click)="copyToClipboard(icon.name)">{{ icon.name }}</span>
+        <mat-icon class="icon-item-preview">{{ icon.name }}</mat-icon>
+        <span class="icon-item-title">{{ icon.name }}</span>
     </div>
 </div>

--- a/src/app/icon-item/icon-item.component.scss
+++ b/src/app/icon-item/icon-item.component.scss
@@ -6,6 +6,8 @@
     text-align: center;
     user-select: none;
 
+    cursor: pointer;
+
     border-radius: 8px;
 
     transition: all 0.25s ease-out;
@@ -35,17 +37,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
 
-    cursor: pointer;
-
     border-radius: 4px;
-
-    transition-duration: 0.3s;
-
-    &:hover {
-        color: white;
-        background-color: rgb(0, 121, 107);
-        box-shadow: 0 4px rgb(3, 162, 143);
-    }
 }
 
 .icon-item-preview {
@@ -54,6 +46,4 @@
     width: 48px;
     height: 48px;
     overflow: hidden;
-
-    cursor: pointer;
 }

--- a/src/app/icon-item/icon-item.component.scss
+++ b/src/app/icon-item/icon-item.component.scss
@@ -1,6 +1,6 @@
 .icon-item-container {
     height: 120px;
-    width: 112px;
+    width: 120px;
     padding: 8px;
     display: inline-block;
     text-align: center;


### PR DESCRIPTION
## Widescreen

| Before                                                                                                                                       | After                                                                                                                    |
|----------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
| ![material-icons-library dugny me_ (1)](https://user-images.githubusercontent.com/35831069/89739659-21d89800-dab5-11ea-9ee1-f72ff925a555.png) | ![localhost_4200_](https://user-images.githubusercontent.com/35831069/89768785-aadfe580-db2e-11ea-8c28-49da87621c6b.png) |

## Mobile

| Before (select menu overflowed)                                                                                                        | After                                                                                                                                  |
|---------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
| ![material-icons-library dugny me_(iPhone X) (4)](https://user-images.githubusercontent.com/35831069/89770764-cc8e9c00-db31-11ea-8df2-9bc677b25e7d.png) | ![localhost_4200_(iPhone X) (1)](https://user-images.githubusercontent.com/35831069/89772323-67887580-db34-11ea-8399-37b785a89ce8.png) |

---

Also take a look at [my project](https://github.com/maxloh/material-design-icons), which download icon files from Google's server, including historical versions.

Maybe it would be useful for you :)